### PR TITLE
fix(smtp): send 421 shutdown response on SIGTERM and SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Send a `421` shutdown response on SIGTERM and SIGINT in `-bs` mode instead
+  of terminating silently. (#3)
+
 ## [1.0.0] - 2026-03-08
 
 Production release.

--- a/src/telegram_sendmail/__main__.py
+++ b/src/telegram_sendmail/__main__.py
@@ -393,9 +393,6 @@ def _run_smtp_mode(config: AppConfig) -> int:
         server = SMTPServer(config, on_message=_make_smtp_handler(config))
         server.run()
         return _EX_OK
-    except KeyboardInterrupt:
-        logger.info("SMTP session interrupted by user")
-        return _EX_OK
     except TelegramSendmailError as exc:
         logger.error("%s", exc)
         return _EX_ERROR

--- a/src/telegram_sendmail/smtp.py
+++ b/src/telegram_sendmail/smtp.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 import os
 import queue
+import signal
 import sys
 import threading
 from collections.abc import Callable
@@ -43,6 +44,11 @@ from telegram_sendmail.exceptions import SMTPProtocolError
 logger = logging.getLogger(__name__)
 
 _MAX_MESSAGE_SIZE: int = 10_485_760  # 10 MiB, advertised via EHLO SIZE extension
+
+# Pushed into line_queue by signal handlers to trigger graceful shutdown.
+# The \x00 prefix cannot arrive from stdin in text mode, preventing
+# collision with any real SMTP command line.
+_SHUTDOWN_SENTINEL: Final = "\x00__SIGNAL_SHUTDOWN__"
 
 
 # --------------------------------------------------------------------------
@@ -67,6 +73,7 @@ class _SMTP:
     MSG_TOO_BIG: Final = "552 5.3.4 Message size exceeds fixed maximum message size"
     TRANSACTION_FAIL: Final = "554 5.0.0 Transaction failed"
     TIMEOUT: Final = "421 4.4.2 Connection timed out"
+    SHUTDOWN: Final = "421 4.4.2 Service shutting down"
     INTERNAL_ERROR: Final = "421 4.3.0 Internal server error"
 
     @staticmethod
@@ -172,7 +179,10 @@ class SMTPServer:
     def run(self) -> None:
         """
         Start the SMTP dialogue. Blocks until the session ends (QUIT,
-        EOF on stdin, or timeout).
+        EOF on stdin, timeout, or shutdown signal).
+
+        SIGTERM and SIGINT are intercepted for the duration of the session
+        so that a process manager receives a proper `421` shutdown response.
 
         Raises:
             SMTPProtocolError: If an unrecoverable I/O error occurs on
@@ -194,6 +204,11 @@ class SMTPServer:
         except AttributeError:
             pass  # reconfigure not available in all environments (e.g. tests)
 
+        prev_signals = {}
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            prev_signals[sig] = signal.getsignal(sig)
+            signal.signal(sig, lambda *_: line_queue.put(_SHUTDOWN_SENTINEL))
+
         session = _SessionState()
         self._write(_SMTP.BANNER)
 
@@ -204,6 +219,11 @@ class SMTPServer:
         except Exception as exc:
             logger.error("SMTP session crashed unexpectedly: %s", exc)
             self._write(_SMTP.INTERNAL_ERROR)
+        finally:
+            # Restore original signal handlers so the caller's environment
+            # stays unaffected.
+            signal.signal(signal.SIGTERM, prev_signals[signal.SIGTERM])
+            signal.signal(signal.SIGINT, prev_signals[signal.SIGINT])
 
     # ------------------------------------------------------------------
     # Event loop
@@ -225,6 +245,11 @@ class SMTPServer:
 
             if line is None:
                 logger.info("SMTP stdin closed (EOF)")
+                return
+
+            if line is _SHUTDOWN_SENTINEL:
+                logger.info("SMTP session terminated by signal")
+                self._write(_SMTP.SHUTDOWN)
                 return
 
             line = line.rstrip("\r\n")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,7 +50,6 @@ Coverage targets
 
 `_run_smtp_mode`
     - Returns _EX_OK (0) when SMTPServer.run() completes without error
-    - Returns _EX_OK (0) when SMTPServer.run() raises KeyboardInterrupt
     - Returns _EX_ERROR (1) when SMTPServer.run() raises TelegramSendmailError
     - Returns _EX_ERROR (1) when SMTPServer.run() raises an unexpected Exception
     - Constructs SMTPServer with a callable on_message handler
@@ -722,17 +721,6 @@ class TestRunSmtpMode:
         self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.setattr(main_module, "SMTPServer", _SMTPServerOk)
-        assert _run_smtp_mode(app_config) == _EX_OK
-
-    def test_keyboard_interrupt_returns_ex_ok(
-        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.setattr(
-            main_module,
-            "SMTPServer",
-            # Ctrl-C is a clean operator shutdown, not a delivery failure.
-            _smtp_server_raising(KeyboardInterrupt()),
-        )
         assert _run_smtp_mode(app_config) == _EX_OK
 
     def test_telegram_sendmail_error_returns_ex_error(

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -62,6 +62,10 @@ Coverage targets
     - A second complete message can be delivered in the same session after RSET
     - Two complete messages can be delivered in a single session without an intervening RSET
 
+`SMTPServer` — signal-triggered graceful shutdown
+    - SIGTERM, SIGINT and shutdown sentinel produce a "421" shutdown response
+    - Signal handlers are restored to their original values after a QUIT or session crash
+
 Design notes
 ------------
 - All integration tests use the `_run_session` module-level helper, which
@@ -73,18 +77,26 @@ Design notes
 - The app_config fixture has smtp_timeout=5. Because StringIO input is
   exhausted nearly instantly, the event loop never waits anywhere near the
   timeout threshold, keeping all tests fast.
+- Both real-signal and sentinel tests (`_shutdown_reader`) exist because
+  real-signal delivery depends on thread scheduling and can be flaky in
+  resource-constrained CI environments.
 """
 
 from __future__ import annotations
 
 import io
+import os
+import signal
 import sys
+import threading
+import time
+from collections.abc import Callable
 from typing import Any, Literal
 
 import pytest
 
 from telegram_sendmail.config import AppConfig
-from telegram_sendmail.smtp import SMTPServer
+from telegram_sendmail.smtp import _SHUTDOWN_SENTINEL, SMTPServer
 
 # --------------------------------------------------------------------------
 # Helpers
@@ -573,3 +585,82 @@ class TestSMTPSessionReset:
         second_raw = smtp_callback.call_args_list[1].args[0]
         assert "first message" in first_raw
         assert "second message" in second_raw
+
+
+# --------------------------------------------------------------------------
+# Signal-triggered graceful shutdown
+# --------------------------------------------------------------------------
+
+
+class TestSMTPSignalShutdown:
+    @staticmethod
+    def _shutdown_reader(signum: int | None = None) -> Callable[[Any], None]:
+        """Return a _stdin_reader that sends a shutdown signal or sentinel after EHLO."""
+
+        def _reader(q: Any) -> None:
+            q.put("EHLO Test\r\n")
+            if signum is not None:
+                time.sleep(0.05)
+                os.kill(os.getpid(), signum)
+                threading.Event().wait()
+            else:
+                q.put(_SHUTDOWN_SENTINEL)
+
+        return _reader
+
+    @pytest.mark.parametrize("signum", [signal.SIGTERM, signal.SIGINT])
+    def test_shutdown_signal_produces_421_shutdown_response(
+        self,
+        signum: int,
+        app_config: AppConfig,
+        smtp_callback: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            SMTPServer, "_stdin_reader", staticmethod(self._shutdown_reader(signum))
+        )
+        server = SMTPServer(app_config, on_message=smtp_callback)
+        output = _run_session(server, [], monkeypatch)
+        assert "Service shutting down" in output
+        smtp_callback.assert_not_called()
+
+    def test_shutdown_sentinel_produces_421_shutdown_response(
+        self,
+        app_config: AppConfig,
+        smtp_callback: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            SMTPServer, "_stdin_reader", staticmethod(self._shutdown_reader())
+        )
+        server = SMTPServer(app_config, on_message=smtp_callback)
+        output = _run_session(server, [], monkeypatch)
+        assert "Service shutting down" in output
+        smtp_callback.assert_not_called()
+
+    def test_signal_handlers_restored_after_normal_quit(
+        self,
+        app_config: AppConfig,
+        smtp_callback: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        prev_term = signal.getsignal(signal.SIGTERM)
+        prev_int = signal.getsignal(signal.SIGINT)
+        server = SMTPServer(app_config, on_message=smtp_callback)
+        _run_session(server, ["QUIT"], monkeypatch)
+        assert signal.getsignal(signal.SIGTERM) is prev_term
+        assert signal.getsignal(signal.SIGINT) is prev_int
+
+    def test_signal_handlers_restored_after_session_crash(
+        self,
+        app_config: AppConfig,
+        smtp_callback: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        smtp_callback.side_effect = RuntimeError("crash")
+        prev_term = signal.getsignal(signal.SIGTERM)
+        prev_int = signal.getsignal(signal.SIGINT)
+        server = SMTPServer(app_config, on_message=smtp_callback)
+        _run_session(server, _commands("DATA", "body", "."), monkeypatch)
+        assert signal.getsignal(signal.SIGTERM) is prev_term
+        assert signal.getsignal(signal.SIGINT) is prev_int


### PR DESCRIPTION
Without a shutdown response, the SMTP client hangs until its own read timeout fires when a process manager sends SIGTERM. The signal now enqueues a shutdown sentinel that the event loop drains into a proper 421 reply before exiting.

Closes #3