### PR TITLE
feat(cli): add --probe flag for config and connectivity validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--probe` flag to validate configuration and verify Telegram API
+  connectivity without reading from stdin. ([#9](https://github.com/theodiv/telegram-sendmail/issues/9))
+
 ### Fixed
 
 - Send a `421` shutdown response on SIGTERM and SIGINT in `-bs` mode instead

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Two modes of operation are supported:
   `-i`, `-oi`, plus silent acceptance of positional recipient arguments
 - Configurable HTTP retry strategy with exponential backoff for resilience
   against transient Telegram API failures
+- Validates configuration and Telegram connectivity via `--probe` without
+  reading from stdin, suitable for provisioning pipelines and smoke tests
 - `EX_TEMPFAIL` (exit code 75) signalling on HTTP 429/5xx so MTA-aware daemons
   re-queue and retry automatically
 - Distributed as a standalone binary with no runtime dependencies via the
@@ -254,6 +256,9 @@ telegram-sendmail -bs
 
 # Interactive debugging with console logging
 echo "Hello" | telegram-sendmail --console --debug
+
+# Dispatch a test message to verify configuration and delivery
+telegram-sendmail --probe
 ```
 
 ## Exit Codes
@@ -284,6 +289,20 @@ journalctl -t telegram-sendmail --since "1 hour ago"
 ```
 
 On systems without `journald`, check `/var/log/mail.log` or `/var/log/syslog`.
+
+### Validating a new installation
+
+The `--probe` flag verifies configuration syntax, bot token validity, and
+`chat_id` reachability in a single command without reading from stdin:
+
+```bash
+telegram-sendmail --probe --console --debug
+```
+
+Exit code `0` confirms end-to-end connectivity. `78` indicates a config
+error, `75` a transient network failure, and `1` a permanent API rejection
+(bad token, unreachable chat). Suitable for Ansible tasks, cloud-init
+`runcmd` assertions, and manual post-install smoke tests.
 
 ### Common issues
 

--- a/src/telegram_sendmail/__main__.py
+++ b/src/telegram_sendmail/__main__.py
@@ -60,6 +60,12 @@ _EX_CONFIG = 78
 _MAX_PIPE_SIZE: int = 10_485_760  # 10 MiB
 _PIPE_READ_CHUNK: int = 65_536
 
+# Sent as a test message when invoked with `--probe` to verify that the
+# delivery pipeline is functional.
+_PROBE_MESSAGE: str = (
+    "🟢 <b>telegram-sendmail probe</b>\n\nConfiguration OK, delivery verified."
+)
+
 
 # --------------------------------------------------------------------------
 # Delivery pipeline
@@ -318,6 +324,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="set log level to DEBUG",
     )
     parser.add_argument(
+        "--probe",
+        action="store_true",
+        help=("validate configuration and send a test message to Telegram chat"),
+    )
+    parser.add_argument(
         "--help",
         action="help",
         help="display this help message and exit",
@@ -341,8 +352,10 @@ def main() -> None:
     """
     CLI entry point registered under `[project.scripts]` in `pyproject.toml`.
 
-    Dispatches to one of three operating modes:
+    Dispatches to one of four operating modes:
 
+    - **Probe mode** (`--probe`): validates the configuration and sends a
+      test message to the configured `chat_id`. No stdin, no spool.
     - **SMTP mode** (`-bs`): runs `SMTPServer.run()` which speaks the
       SMTP protocol on `stdin`/`stdout`.
     - **Pipe mode** (stdin is not a TTY): reads a raw email from `stdin`
@@ -378,12 +391,47 @@ def main() -> None:
     for handler in logging.root.handlers:
         handler.addFilter(token_filter)
 
-    if args.bs:
+    if args.probe:
+        sys.exit(_run_probe_mode(config))
+    elif args.bs:
         sys.exit(_run_smtp_mode(config))
     elif not sys.stdin.isatty():
         sys.exit(_run_pipe_mode(args.sender, args.subject, config))
     else:
         sys.exit(_run_interactive_mode())
+
+
+def _run_probe_mode(config: AppConfig) -> int:
+    """
+    Validate configuration and verify Telegram API connectivity.
+
+    Sends a short test message to the configured `chat_id` without reading
+    from stdin or writing to the spool. Exit code mapping mirrors the normal
+    delivery path so provisioning tools or smoke tests get the same signals.
+    """
+    logger.info("Probe mode: sending test message to chat_id %s", config.chat_id)
+    try:
+        with TelegramClient(config) as client:
+            client.send(_PROBE_MESSAGE)
+        logger.info("Probe succeeded")
+        return _EX_OK
+    except TelegramAPIError as exc:
+        status = getattr(exc, "status_code", None)
+        if status is not None and status in _RETRY_STATUS_CODES:
+            logger.warning(
+                "Probe hit transient Telegram API failure (HTTP %d); "
+                "signalling EX_TEMPFAIL",
+                status,
+            )
+            return _EX_TEMPFAIL
+        logger.error("Probe failed: %s", exc)
+        return _EX_ERROR
+    except TelegramSendmailError as exc:
+        logger.error("Probe failed: %s", exc)
+        return _EX_ERROR
+    except Exception as exc:
+        logger.error("Unexpected error during probe: %s", exc)
+        return _EX_ERROR
 
 
 def _run_smtp_mode(config: AppConfig) -> int:
@@ -465,6 +513,7 @@ def _run_interactive_mode() -> int:
         "\n"
         "Pipe mode:  echo -e 'Subject: Test\\n\\nHello' | telegram-sendmail\n"
         "SMTP mode:  telegram-sendmail -bs\n"
+        "Probe mode: telegram-sendmail --probe\n"
         "Debug mode: echo 'test' | telegram-sendmail --console --debug\n"
         "\n"
         "For full documentation: telegram-sendmail --help",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,12 +45,22 @@ Coverage targets
       or an unexpected Exception
     - Constructs SMTPServer with a callable on_message handler
 
+`_run_probe_mode`
+    - Returns _EX_OK (0) when test message is delivered successfully
+    - Sends _PROBE_MESSAGE as the text payload and to the configured chat_id
+    - Returns _EX_ERROR (1) when TelegramAPIError has a non-retriable or no status code
+    - Returns _EX_ERROR (1) when TelegramSendmailError or an unexpected Exception is raised
+    - Returns _EX_TEMPFAIL (75) when TelegramAPIError has a retriable status code (429, 500)
+    - Does not read from stdin and does not write to the spool file
+    - Logs success at INFO level and an "EX_TEMPFAIL" WARNING on transient failure
+
 `_run_interactive_mode`
     - Returns _EX_ERROR (1)
     - Writes all output to sys.stderr (stdout remains empty)
     - Output contains the package version string
     - Output mentions "Pipe mode:" with a usage example
     - Output mentions "SMTP mode:" and the -bs flag
+    - Output mentions "Probe mode:" and the --probe flag
     - Output mentions "--help" to direct the operator to full documentation
 
 `main`
@@ -59,6 +69,8 @@ Coverage targets
     - Calls sys.exit(0) when pipe-mode delivery succeeds with non-TTY stdin
     - Invokes SMTPServer (via _run_smtp_mode) and calls sys.exit(0) when the -bs flag
       is present and the SMTP session completes cleanly
+    - Calls sys.exit(0) when --probe flag is present and probe succeeds
+    - --probe takes dispatch priority over -bs if both are present
     - Calls sys.exit(75) when pipe-mode hits HTTP 429 rate limit
     - Installs a _TokenRedactFilter on every root-logger handler after config is loaded
     - Logs ConfigurationError at ERROR level before exiting with code 78
@@ -83,9 +95,10 @@ from __future__ import annotations
 import io
 import logging
 import sys
-from typing import Any
+from typing import Any, TextIO
 
 import pytest
+import requests_mock as requests_mock_module
 
 import telegram_sendmail.__main__ as main_module
 import telegram_sendmail.config as cfg_module
@@ -96,10 +109,12 @@ from telegram_sendmail.__main__ import (
     _EX_OK,
     _EX_TEMPFAIL,
     _MAX_PIPE_SIZE,
+    _PROBE_MESSAGE,
     _bounded_stdin_read,
     _deliver,
     _run_interactive_mode,
     _run_pipe_mode,
+    _run_probe_mode,
     _run_smtp_mode,
     _TokenRedactFilter,
     main,
@@ -567,7 +582,7 @@ class TestRunPipeMode:
         monkeypatch.setattr(
             main_module,
             "_deliver",
-            self._fail_with(TelegramAPIError("bad Request", status_code=400)),
+            self._fail_with(TelegramAPIError("bad request", status_code=400)),
         )
         monkeypatch.setattr(sys, "stdin", io.StringIO("email"))
         assert _run_pipe_mode(None, None, app_config) == _EX_ERROR
@@ -659,7 +674,7 @@ class TestRunPipeMode:
         monkeypatch.setattr(
             main_module,
             "_deliver",
-            self._fail_with(TelegramAPIError("Too Many Requests", status_code=429)),
+            self._fail_with(TelegramAPIError("too many requests", status_code=429)),
         )
         monkeypatch.setattr(sys, "stdin", io.StringIO("email"))
         with caplog.at_level(logging.WARNING, logger="telegram_sendmail.__main__"):
@@ -736,6 +751,177 @@ class TestRunSmtpMode:
 
 
 # --------------------------------------------------------------------------
+# _run_probe_mode — config validation and Telegram connectivity check
+# --------------------------------------------------------------------------
+
+
+class TestRunProbeMode:
+    class _SpyStdin:
+        """stdin stub that records whether read() was called."""
+
+        def __init__(self, stdin: TextIO) -> None:
+            self._original_stdin = stdin
+            self._read_called = False
+
+        def read(self, *args: Any) -> str:
+            self._read_called = True
+            return ""
+
+        def isatty(self) -> bool:
+            return self._original_stdin.isatty()
+
+    @staticmethod
+    def _client_raising(exc: BaseException) -> type[Any]:
+        """Return a stub TelegramClient class whose send() raises exc."""
+
+        class _Stub:
+            def __init__(self, config: AppConfig) -> None:
+                pass
+
+            def __enter__(self) -> _Stub:
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                pass
+
+            def send(self, text: str) -> None:
+                raise exc
+
+        return _Stub
+
+    def test_success_returns_ex_ok(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        assert _run_probe_mode(app_config) == _EX_OK
+
+    def test_sends_probe_message_text(
+        self,
+        app_config: AppConfig,
+        mock_telegram_ok: requests_mock_module.Mocker,
+    ):
+        _run_probe_mode(app_config)
+        assert mock_telegram_ok.last_request.json()["text"] == _PROBE_MESSAGE
+
+    def test_sends_to_configured_chat_id(
+        self,
+        app_config: AppConfig,
+        mock_telegram_ok: requests_mock_module.Mocker,
+    ):
+        _run_probe_mode(app_config)
+        assert mock_telegram_ok.last_request.json()["chat_id"] == app_config.chat_id
+
+    def test_telegram_api_error_non_retriable_returns_ex_error(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramAPIError("bad request", status_code=400)),
+        )
+        assert _run_probe_mode(app_config) == _EX_ERROR
+
+    def test_telegram_api_error_429_returns_ex_tempfail(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramAPIError("rate limited", status_code=429)),
+        )
+        assert _run_probe_mode(app_config) == _EX_TEMPFAIL
+
+    def test_telegram_api_error_500_returns_ex_tempfail(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramAPIError("server error", status_code=500)),
+        )
+        assert _run_probe_mode(app_config) == _EX_TEMPFAIL
+
+    def test_telegram_api_error_no_status_returns_ex_error(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramAPIError("connection refused")),
+        )
+        assert _run_probe_mode(app_config) == _EX_ERROR
+
+    def test_telegram_sendmail_error_returns_ex_error(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramSendmailError("generic failure")),
+        )
+        assert _run_probe_mode(app_config) == _EX_ERROR
+
+    def test_unexpected_exception_returns_ex_error(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(RuntimeError("unexpected error")),
+        )
+        assert _run_probe_mode(app_config) == _EX_ERROR
+
+    def test_does_not_read_stdin(
+        self,
+        app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        spy_stdin = self._SpyStdin(sys.stdin)
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        monkeypatch.setattr(sys, "stdin", spy_stdin)
+        _run_probe_mode(app_config)
+        assert not spy_stdin._read_called
+
+    def test_does_not_write_to_spool(
+        self,
+        app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        _run_probe_mode(app_config)
+        assert not app_config.spool_path.exists()
+
+    def test_logs_info_on_success(
+        self,
+        app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        with caplog.at_level(logging.INFO, logger="telegram_sendmail.__main__"):
+            _run_probe_mode(app_config)
+        assert any("Probe succeeded" in r.message for r in caplog.records)
+
+    def test_logs_warning_on_transient_failure(
+        self,
+        app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        monkeypatch.setattr(
+            main_module,
+            "TelegramClient",
+            self._client_raising(TelegramAPIError("rate limited", status_code=429)),
+        )
+        with caplog.at_level(logging.WARNING, logger="telegram_sendmail.__main__"):
+            _run_probe_mode(app_config)
+        assert any(
+            "EX_TEMPFAIL" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+
+
+# --------------------------------------------------------------------------
 # _run_interactive_mode — stderr output and return value
 # --------------------------------------------------------------------------
 
@@ -770,6 +956,14 @@ class TestRunInteractiveMode:
         assert "SMTP mode:" in err
         assert "-bs" in err
 
+    def test_stderr_output_mentions_probe_mode_and_probe_flag(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        _run_interactive_mode()
+        err = capsys.readouterr().err
+        assert "Probe mode:" in err
+        assert "--probe" in err
+
     def test_stderr_output_directs_to_help_flag(
         self, capsys: pytest.CaptureFixture[str]
     ):
@@ -798,7 +992,7 @@ class TestMainDispatch:
     @staticmethod
     def _raise_rate_limit(raw: str, sender: Any, config: Any):
         """Simulate Telegram API rate limit by raising TelegramAPIError with 429."""
-        raise TelegramAPIError("Too Many Requests", status_code=429)
+        raise TelegramAPIError("too many requests", status_code=429)
 
     def test_configuration_error_exits_with_code_78(
         self,
@@ -850,6 +1044,35 @@ class TestMainDispatch:
         monkeypatch.setattr(main_module, "SMTPServer", _SMTPServerOk)
         with pytest.raises(SystemExit) as exc_info:
             main()
+        assert exc_info.value.code == _EX_OK
+
+    def test_probe_flag_invokes_probe_mode_and_exits_0(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        patched_config_loader: AppConfig,
+        no_setup_logging: None,
+    ):
+        monkeypatch.setattr(sys, "argv", ["telegram-sendmail", "--probe"])
+        # stdin is a TTY; probe must not fall through to interactive mode.
+        monkeypatch.setattr(sys, "stdin", self._FakeTTY())
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == _EX_OK
+
+    def test_probe_flag_takes_priority_over_bs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        patched_config_loader: AppConfig,
+        no_setup_logging: None,
+    ):
+        monkeypatch.setattr(sys, "argv", ["telegram-sendmail", "-bs", "--probe"])
+        monkeypatch.setattr(sys, "stdin", self._FakeTTY())
+        monkeypatch.setattr(main_module, "TelegramClient", _ClientOk)
+        monkeypatch.setattr(main_module, "SMTPServer", RuntimeError, True)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        # --probe wins over -bs; exit 0 from probe, not 1 from SMTP.
         assert exc_info.value.code == _EX_OK
 
     def test_pipe_mode_rate_limit_exits_75_via_main(


### PR DESCRIPTION
Provisioning tools (Ansible, cloud-init) need a stdin-free, exit-code-bearing command to assert a working installation before the host enters service. --probe validates the config and sends a short test message to the configured chat_id without reading from stdin or writing to spool.

Closes #9