### PR TITLE
feat(config): add [filters] section for suppressing subjects and senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `[filters]` INI section with `suppress_subject` and `suppress_sender`
+  multi-line keys for glob-based message suppression. ([#12](https://github.com/theodiv/telegram-sendmail/issues/12))
+
 ## [1.1.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Two modes of operation are supported:
   `-i`, `-oi`, plus silent acceptance of positional recipient arguments
 - Configurable HTTP retry strategy with exponential backoff for resilience
   against transient Telegram API failures
+- Suppresses known-noisy messages via case-insensitive glob patterns on
+  `Subject` and `From` headers, keeping the destination chat focused on
+  actionable alerts
 - Validates configuration and Telegram connectivity via `--probe` without
   reading from stdin, suitable for provisioning pipelines and smoke tests
 - `EX_TEMPFAIL` (exit code 75) signalling on HTTP 429/5xx so MTA-aware daemons
@@ -186,8 +189,8 @@ chat_id = -1001234567890
 ; All keys below are optional. Out-of-range or malformed values fall
 ; back to their documented defaults with a WARNING logged to syslog.
 
-; Spool directory. Effective path: <spool_dir>/<username>
-; Default: /var/mail
+; Spool directory. Default: /var/mail
+; Effective path: <spool_dir>/<username>
 spool_dir = /var/mail
 
 ; Maximum body length forwarded to Telegram (100–4096). Default: 3800
@@ -208,7 +211,23 @@ backoff_factor = 0.5
 
 ; Suppress notification sound and banner. Default: false
 disable_notification = false
+
+[filters]
+; Suppress noisy messages by Subject header. Default: (none)
+; suppress_subject =
+;   cron *
+;   *logwatch*
+;
+; Suppress noisy messages by From header. Default: (none)
+; suppress_sender =
+;   *@noreply.local
 ```
+
+Messages matching any `suppress_subject` or `suppress_sender` glob pattern in
+the `[filters]` section are archived to the spool file but skipped for
+Telegram delivery. Patterns use Python `fnmatch` semantics (`*`, `?`,
+`[seq]`) and are case-insensitive. Multiple patterns are specified one per
+line, indented under the key.
 
 The complete annotated template is provided in
 [`telegram-sendmail.ini.example`](telegram-sendmail.ini.example).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,8 @@ Two delivery modes:
 - Full `sendmail`-compatible flag support: `-f`, `-r`, `-s`, `-bs`, `-t`,
   `-i`, `-oi`, plus silent acceptance of positional recipient arguments
 - Configurable HTTP retry strategy with exponential backoff
+- Suppresses known-noisy messages via case-insensitive glob patterns on
+  `Subject` and `From` headers
 - `EX_TEMPFAIL` (exit code 75) on HTTP 429/5xx so MTA-aware daemons
   re-queue and retry automatically
 
@@ -70,6 +72,10 @@ chat_id = -1001234567890
 ; max_retries           = 3         (0–10)
 ; backoff_factor        = 0.5       (0.0–10.0)
 ; disable_notification  = false
+
+[filters]
+; suppress_subject =                (case-insensitive globs)
+; suppress_sender  =                (case-insensitive globs)
 ```
 
 The config file contains the bot token. Permissions **must** be `0600`; a

--- a/src/telegram_sendmail/__main__.py
+++ b/src/telegram_sendmail/__main__.py
@@ -28,6 +28,7 @@ Exit codes
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import logging
 import logging.handlers
 import sys
@@ -43,7 +44,7 @@ from telegram_sendmail.exceptions import (
     TelegramAPIError,
     TelegramSendmailError,
 )
-from telegram_sendmail.parser import EmailParser
+from telegram_sendmail.parser import EmailParser, ParsedEmail
 from telegram_sendmail.smtp import SMTPServer
 from telegram_sendmail.spool import MailSpooler
 
@@ -84,8 +85,10 @@ def _deliver(
     1. **Spool**  — archive the raw email. Non-fatal: a `SpoolError` is
                     logged at WARNING level and delivery continues.
     2. **Parse**  — decode MIME structure and convert body to Telegram markup.
-    3. **Format** — wrap in the Telegram message envelope with truncation.
-    4. **Send**   — deliver via the Telegram Bot API.
+    3. **Filter** — check Subject and From headers against configured
+                    suppression patterns. Matched messages return early.
+    4. **Format** — wrap in the Telegram message envelope with truncation.
+    5. **Send**   — deliver via the Telegram Bot API.
 
     Args:
         raw_email:       Raw RFC 2822 email string.
@@ -105,10 +108,47 @@ def _deliver(
 
     parser = EmailParser(config)
     parsed = parser.parse(raw_email, sender_override=sender_override)
+
+    if _is_suppressed(parsed, config):
+        return
+
     text = parser.format_for_telegram(parsed)
 
     with TelegramClient(config) as client:
         client.send(text)
+
+
+def _is_suppressed(parsed: ParsedEmail, config: AppConfig) -> bool:
+    """
+    Check parsed email headers against the configured suppression patterns.
+
+    Pattern matching uses `fnmatch` (case-insensitive) so operators can
+    write shell-style globs in the INI file. The check runs against the
+    fully resolved sender and subject — including CLI overrides and
+    RFC 2047 decoding — so suppression patterns match exactly what would
+    appear in the Telegram message.
+
+    Returns:
+        `True` if any pattern matches, `False` otherwise.
+    """
+    suppression_checks = (
+        ("Subject", parsed.subject, config.suppress_subject),
+        ("From", parsed.sender, config.suppress_sender),
+    )
+
+    for name, value, patterns in suppression_checks:
+        if not patterns:
+            continue
+
+        value_lower = value.lower()
+        for pattern in patterns:
+            if fnmatch.fnmatch(value_lower, pattern.lower()):
+                logger.debug(
+                    "Suppressed: %s '%s' matched pattern '%s'", name, value, pattern
+                )
+                return True
+
+    return False
 
 
 def _make_smtp_handler(config: AppConfig) -> Callable[[str, str | None], None]:

--- a/src/telegram_sendmail/config.py
+++ b/src/telegram_sendmail/config.py
@@ -81,6 +81,12 @@ class AppConfig:
                               `urllib3`'s exponential backoff algorithm.
                               Effective sleep between attempt *n* and *n+1* is
                               `backoff_factor * (2 ** (n - 1))` seconds.
+        suppress_subject:     Case-insensitive glob patterns matched against
+                              the Subject header. Matching messages are
+                              spooled but skipped for Telegram delivery.
+        suppress_sender:      Case-insensitive glob patterns matched against
+                              the From header. Same suppression semantics as
+                              `suppress_subject`.
     """
 
     token: str
@@ -92,6 +98,8 @@ class AppConfig:
     spool_path: Path
     max_retries: int
     backoff_factor: float
+    suppress_subject: tuple[str, ...] = ()
+    suppress_sender: tuple[str, ...] = ()
 
 
 # --------------------------------------------------------------------------
@@ -418,6 +426,42 @@ def _parse_options(
     )
 
 
+def _parse_filters(
+    parser: configparser.ConfigParser,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """
+    Extract glob patterns from the `[filters]` INI section.
+
+    Each multi-line key is split on newlines; empty lines and
+    whitespace-only entries are silently dropped. The function never
+    raises — a missing section or empty keys simply produce empty tuples
+    so that delivery is never blocked by a filter misconfiguration.
+
+    Returns:
+        A tuple of `(suppress_subject, suppress_sender)`.
+    """
+    if not parser.has_section("filters"):
+        return ((), ())
+
+    def _read_patterns(key: str) -> tuple[str, ...]:
+        if not parser.has_option("filters", key):
+            return ()
+        raw = parser.get("filters", key)
+        patterns = tuple(line.strip() for line in raw.splitlines() if line.strip())
+        if patterns:
+            logger.debug(
+                "Loaded %d suppression pattern(s) from [filters] %s",
+                len(patterns),
+                key,
+            )
+        return patterns
+
+    return (
+        _read_patterns("suppress_subject"),
+        _read_patterns("suppress_sender"),
+    )
+
+
 # --------------------------------------------------------------------------
 # Public interface
 # --------------------------------------------------------------------------
@@ -481,6 +525,8 @@ class ConfigLoader:
             backoff_factor,
         ) = _parse_options(parser, config_file)
 
+        suppress_subject, suppress_sender = _parse_filters(parser)
+
         logger.debug("Configuration loaded successfully from '%s'", config_file)
 
         return AppConfig(
@@ -493,4 +539,6 @@ class ConfigLoader:
             spool_path=spool_path,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            suppress_subject=suppress_subject,
+            suppress_sender=suppress_sender,
         )

--- a/telegram-sendmail.ini.example
+++ b/telegram-sendmail.ini.example
@@ -88,3 +88,29 @@ backoff_factor = 0.5
 ;
 ; Default: false
 disable_notification = false
+
+
+[filters]
+
+; Suppress known-noisy messages from being forwarded to Telegram.
+; Matched messages are still archived to the spool file for audit.
+; Each key accepts one or more case-insensitive glob patterns (Python
+; fnmatch semantics: *, ?, [seq], [!seq]). Place each pattern on its
+; own line, indented under the key.
+
+; Suppress messages whose Subject header matches any of these patterns.
+; Example: skip routine cron output and logwatch daily digests.
+;
+; Default: (none)
+; suppress_subject =
+;   cron *
+;   *logwatch*
+;   daily backup*
+
+; Suppress messages whose From header matches any of these patterns.
+; Example: skip messages from automated noreply senders.
+;
+; Default: (none)
+; suppress_sender =
+;   *@noreply.local
+;   root@monitoring.*

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,14 @@ Coverage targets
     - Accepts a valid max_retries integer
     - Uses the configured spool_dir as the parent of the resolved spool path
 
+`_parse_filters`
+    - Returns empty tuples when the [filters] section is absent or has no keys
+    - Parses a single suppress_subject or suppress_sender pattern
+    - Parses multiline values into separate patterns
+    - Strips whitespace and drops blank lines from pattern lists
+    - Parses both keys together when both are present
+    - Logs a DEBUG message reporting the count of loaded patterns
+
 `ConfigLoader.load`
     - Raises ConfigurationError when no config file is found on disk
     - Raises ConfigurationError when the config file exists but is not readable
@@ -56,6 +64,7 @@ Coverage targets
     - Raises ConfigurationError when the [telegram] chat_id key is absent
     - Returns a fully populated AppConfig for a minimal valid config file
     - Parses all [options] keys correctly into the returned AppConfig
+    - Populates suppress_subject and suppress_sender from [filters] section
     - Prefers the user config over the system config when both are present
     - Returns the system config when only the system config exists
     - Returns a frozen (immutable) AppConfig instance
@@ -97,6 +106,7 @@ from telegram_sendmail.config import (
     ConfigLoader,
     _audit_permissions,
     _locate_config_file,
+    _parse_filters,
     _parse_options,
     _require,
     _resolve_spool_path,
@@ -110,12 +120,15 @@ from telegram_sendmail.exceptions import ConfigurationError
 # --------------------------------------------------------------------------
 
 
-def _parser_with(**options: Any) -> configparser.ConfigParser:
-    """Return a ConfigParser with an [options] section populated from kwargs."""
+def _parser_with(**kwargs: Any) -> configparser.ConfigParser:
+    """Return a ConfigParser with keys mapped into their respective sections."""
+    key_map = {"filters": ("suppress_subject", "suppress_sender")}
     cp = configparser.ConfigParser(interpolation=None)
-    cp.add_section("options")
-    for key, value in options.items():
-        cp.set("options", key, str(value))
+    for key, value in kwargs.items():
+        section = next((s for s, keys in key_map.items() if key in keys), "options")
+        if not cp.has_section(section):
+            cp.add_section(section)
+        cp.set(section, key, str(value))
     return cp
 
 
@@ -564,6 +577,64 @@ class TestParseOptions:
 
 
 # --------------------------------------------------------------------------
+# _parse_filters
+# --------------------------------------------------------------------------
+
+
+class TestParseFilters:
+    def test_returns_empty_tuples_when_filters_section_absent(self):
+        parser = configparser.ConfigParser(interpolation=None)
+        assert _parse_filters(parser) == ((), ())
+
+    def test_returns_empty_tuples_when_filters_section_has_no_keys(self):
+        parser = configparser.ConfigParser(interpolation=None)
+        parser.add_section("filters")
+        assert _parse_filters(parser) == ((), ())
+
+    def test_parses_single_suppress_subject_pattern(self):
+        parser = _parser_with(suppress_subject="cron *")
+        subjects, senders = _parse_filters(parser)
+        assert subjects == ("cron *",)
+        assert senders == ()
+
+    def test_parses_single_suppress_sender_pattern(self):
+        parser = _parser_with(suppress_sender="*@noreply.local")
+        subjects, senders = _parse_filters(parser)
+        assert subjects == ()
+        assert senders == ("*@noreply.local",)
+
+    def test_parses_multiline_suppress_subject_patterns(self):
+        parser = _parser_with(suppress_subject="cron *\n*logwatch*\n  daily backup*  ")
+        subjects, _ = _parse_filters(parser)
+        assert subjects == ("cron *", "*logwatch*", "daily backup*")
+
+    def test_parses_multiline_suppress_sender_patterns(self):
+        parser = _parser_with(suppress_sender="*@noreply.*\nroot@*\n  daemon@local  ")
+        _, senders = _parse_filters(parser)
+        assert senders == ("*@noreply.*", "root@*", "daemon@local")
+
+    def test_strips_whitespace_and_drops_blank_lines(self):
+        parser = _parser_with(suppress_subject="\n  \n  pattern*  \n\n  *glob  \n  ")
+        subjects, _ = _parse_filters(parser)
+        assert subjects == ("pattern*", "*glob")
+
+    def test_both_keys_parsed_together(self):
+        parser = _parser_with(suppress_subject="subj*", suppress_sender="sender@*")
+        subjects, senders = _parse_filters(parser)
+        assert subjects == ("subj*",)
+        assert senders == ("sender@*",)
+
+    def test_logs_debug_when_patterns_loaded(self, caplog: pytest.LogCaptureFixture):
+        parser = _parser_with(suppress_subject="cron *\n*logwatch*")
+        with caplog.at_level(logging.DEBUG, logger="telegram_sendmail.config"):
+            _parse_filters(parser)
+        assert any(
+            "2 suppression pattern(s)" in r.message and "suppress_subject" in r.message
+            for r in caplog.records
+        )
+
+
+# --------------------------------------------------------------------------
 # ConfigLoader.load — end-to-end integration
 # --------------------------------------------------------------------------
 
@@ -644,6 +715,21 @@ class TestConfigLoaderLoad:
         assert config.max_retries == 5
         assert config.backoff_factor == 1.0
         assert config.disable_notification is True
+
+    def test_populates_suppress_fields_from_filters_section(
+        self, patched_config_constants: dict[str, Path]
+    ):
+        user_ini = patched_config_constants["user_ini"]
+        user_ini.write_text(
+            "[telegram]\ntoken = t\nchat_id = -1\n"
+            "[filters]\n"
+            "suppress_subject =\n  cron*\n  *logwatch*\n"
+            "suppress_sender =\n  root@*\n"
+        )
+        user_ini.chmod(0o600)
+        config = ConfigLoader.load()
+        assert config.suppress_subject == ("cron*", "*logwatch*")
+        assert config.suppress_sender == ("root@*",)
 
     def test_user_config_preferred_over_system_config(
         self, patched_config_constants: dict[str, Path]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,13 @@ Tests for telegram_sendmail.__main__.
 
 Coverage targets
 ----------------
+`_is_suppressed`
+    - Returns False when no patterns are configured or neither header matches any pattern
+    - Returns True when the subject or sender matches a configured glob pattern
+    - Matching is case-insensitive for both subject and sender patterns
+    - Subject patterns are checked before sender patterns
+    - Logs a DEBUG message identifying the matched header and pattern
+
 `_bounded_stdin_read`
     - Returns full content when input is under or exactly at `_MAX_PIPE_SIZE`
     - Truncates oversized input to exactly `_MAX_PIPE_SIZE` characters and emits a WARNING
@@ -17,6 +24,9 @@ Coverage targets
 
 `_deliver`
     - Invokes all three pipeline stages (spool -> parse -> send) in order on the happy path
+    - Skips format_for_telegram and TelegramClient.send when _is_suppressed returns True
+    - Still invokes MailSpooler.write and EmailParser.parse for suppressed messages
+    - Proceeds through the full pipeline when no suppression pattern matches
     - Catches SpoolError without propagating it so delivery continues
     - Invokes EmailParser.parse and TelegramClient.send even when the spool write fails
     - Logs a WARNING via the spool logger before raising SpoolError
@@ -95,6 +105,7 @@ from __future__ import annotations
 import io
 import logging
 import sys
+from dataclasses import replace
 from typing import Any, TextIO
 
 import pytest
@@ -112,6 +123,7 @@ from telegram_sendmail.__main__ import (
     _PROBE_MESSAGE,
     _bounded_stdin_read,
     _deliver,
+    _is_suppressed,
     _run_interactive_mode,
     _run_pipe_mode,
     _run_probe_mode,
@@ -218,6 +230,76 @@ class _SMTPServerOk:
 def no_setup_logging(monkeypatch: pytest.MonkeyPatch):
     """Prevent _setup_logging from attaching handlers to logging.root."""
     monkeypatch.setattr(main_module, "_setup_logging", lambda **_: None)
+
+
+@pytest.fixture
+def app_config_with_filters(app_config: AppConfig) -> AppConfig:
+    """Return `app_config` with subject and sender suppression patterns."""
+    return replace(
+        app_config,
+        suppress_subject=("cron *", "*logwatch*"),
+        suppress_sender=("*@noreply.local",),
+    )
+
+
+# --------------------------------------------------------------------------
+# _is_suppressed — filter pattern matching
+# --------------------------------------------------------------------------
+
+
+class TestIsSuppressed:
+    def test_returns_false_when_no_patterns_configured(self, app_config: AppConfig):
+        assert _is_suppressed(_FAKE_PARSED, app_config) is False
+
+    def test_returns_true_when_subject_matches_pattern(
+        self, app_config_with_filters: AppConfig
+    ):
+        parsed = replace(_FAKE_PARSED, subject="Cron Job Success")
+        assert _is_suppressed(parsed, app_config_with_filters) is True
+
+    def test_returns_true_when_sender_matches_pattern(
+        self, app_config_with_filters: AppConfig
+    ):
+        parsed = replace(_FAKE_PARSED, sender="daemon@noreply.local")
+        assert _is_suppressed(parsed, app_config_with_filters) is True
+
+    def test_returns_false_when_neither_header_matches(
+        self, app_config_with_filters: AppConfig
+    ):
+        assert _is_suppressed(_FAKE_PARSED, app_config_with_filters) is False
+
+    def test_matching_is_case_insensitive(self, app_config: AppConfig):
+        config = replace(app_config, suppress_subject=("CRON *",))
+        parsed = replace(_FAKE_PARSED, subject="cron job output")
+        assert _is_suppressed(parsed, config) is True
+
+    def test_subject_checked_before_sender(
+        self,
+        app_config: AppConfig,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        config = replace(
+            app_config, suppress_subject=("match*",), suppress_sender=("match@*",)
+        )
+        parsed = replace(_FAKE_PARSED, sender="match@host.local", subject="Match This")
+        with caplog.at_level(logging.DEBUG, logger="telegram_sendmail.__main__"):
+            result = _is_suppressed(parsed, config)
+        assert result is True
+        # Subject match fires first; the DEBUG log should reference Subject.
+        assert any("Subject" in r.message for r in caplog.records)
+        assert not any("From" in r.message for r in caplog.records)
+
+    def test_logs_debug_with_matched_pattern(
+        self,
+        app_config_with_filters: AppConfig,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        parsed = replace(_FAKE_PARSED, subject="Logwatch Daily Report")
+        with caplog.at_level(logging.DEBUG, logger="telegram_sendmail.__main__"):
+            _is_suppressed(parsed, app_config_with_filters)
+        assert any(
+            "*logwatch*" in r.message and "Subject" in r.message for r in caplog.records
+        )
 
 
 # --------------------------------------------------------------------------
@@ -404,6 +486,28 @@ class TestDeliverPipeline:
         monkeypatch.setattr(main_module, "TelegramClient", self._TrackingClient)
         _deliver("raw email", None, app_config)
         assert self._stages == ["spool", "parse", "send"]
+
+    def test_non_matching_message_proceeds_through_full_pipeline(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        type(self)._stages = []
+        config = replace(app_config, suppress_subject=("no match*",))
+        monkeypatch.setattr(main_module, "MailSpooler", self._TrackingSpooler)
+        monkeypatch.setattr(main_module, "EmailParser", self._TrackingParser)
+        monkeypatch.setattr(main_module, "TelegramClient", self._TrackingClient)
+        _deliver("raw email", None, config)
+        assert self._stages == ["spool", "parse", "send"]
+
+    def test_suppressed_message_still_spools_and_skips_send(
+        self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        type(self)._stages = []
+        config = replace(app_config, suppress_subject=("disk alert",))
+        monkeypatch.setattr(main_module, "MailSpooler", self._TrackingSpooler)
+        monkeypatch.setattr(main_module, "EmailParser", self._TrackingParser)
+        monkeypatch.setattr(main_module, "TelegramClient", self._TrackingClient)
+        _deliver("raw email", None, config)
+        assert self._stages == ["spool", "parse"]
 
     def test_spool_error_does_not_propagate(
         self, app_config: AppConfig, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Operators can now suppress known-noisy messages before Telegram delivery via case-insensitive glob patterns in the INI file. Matched messages are still spooled for audit.

Closes #12