### PR TITLE
docs: use descriptive titles for .md cross-reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,21 +130,21 @@ valid, the bot token is accepted, and the `chat_id` is reachable. Exit code
 ## Contributing
 
 Development setup, coding standards, and the pull request process are
-documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+documented in the [Contributing Guide](CONTRIBUTING.md).
 
 ## Code of Conduct
 
 Behavioural expectations for all project participants are governed by
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Changelog
 
-A detailed version history is maintained in [CHANGELOG.md](CHANGELOG.md).
+A detailed version history is maintained in the [Changelog](CHANGELOG.md).
 
 ## Security
 
 The threat model, hardening recommendations, and vulnerability disclosure
-process are documented in [SECURITY.md](SECURITY.md).
+process are documented in the [Security Policy](SECURITY.md).
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -130,8 +130,9 @@ cd telegram-sendmail
 pip install -e .
 ```
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for instructions on installing the
-development dependencies and configuring the full quality toolchain.
+See the [Contributing Guide](../CONTRIBUTING.md) for instructions on
+installing the development dependencies and configuring the full quality
+toolchain.
 
 ## Configuration
 
@@ -528,7 +529,7 @@ the path. The `O_NOFOLLOW` flag prevents symlink redirection attacks. These
 measures are described in detail in the [Mail Spooling](#mail-spooling) section.
 
 For the full threat model, hardening recommendations, and vulnerability
-reporting process, see [SECURITY.md](../SECURITY.md).
+reporting process, see the [Security Policy](../SECURITY.md).
 
 ## Exit Codes
 
@@ -702,20 +703,20 @@ sudo rm -rf /var/mail/$(whoami)    # adjust if spool_dir was customised
 ## Contributing
 
 Development setup instructions, coding standards, and the pull request
-process are documented in [CONTRIBUTING.md](../CONTRIBUTING.md).
+process are documented in the [Contributing Guide](../CONTRIBUTING.md).
 
 ## Code of Conduct
 
 Behavioural expectations for all project participants are governed by
-[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+the [Code of Conduct](../CODE_OF_CONDUCT.md).
 
 ## Changelog
 
 A detailed version history following the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format is
-maintained in [CHANGELOG.md](../CHANGELOG.md).
+maintained in the [Changelog](../CHANGELOG.md).
 
 ## Security
 
 The threat model, security hardening recommendations, and the vulnerability
-disclosure process are documented in [SECURITY.md](../SECURITY.md).
+disclosure process are documented in the [Security Policy](../SECURITY.md).


### PR DESCRIPTION
## Description

<!-- Explain what changed and why. Link the related issue if one exists. -->

Replace raw `.md` filename link text with purpose-describing titles in
`README.md` and `docs/USER_GUIDE.md`. Hrefs are unchanged; only the
visible link text is updated.

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor (no functional change)
- [x] Documentation
- [ ] CI / build
- [ ] Chore (dependency bumps, config changes)

## Pre-Submission Checklist

<!-- All items must be checked before requesting review. -->

- [ ] `pre-commit run --all-files` passes
- [ ] `pytest` passes with coverage at or above the global 80% threshold
- [ ] `python scripts/module_coverage.py` passes (90% gate on critical modules)
- [ ] Tests added or updated for all changed logic
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (skip for no operator-visible effect)
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
