### PR TITLE
refactor(parser): reduce Telegram message envelope character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Compact Telegram message envelope by removing the static "New Notification"
+  header, along with the "From:" and "Subject:" labels.
+
 ## [1.2.0] - 2026-03-14
 
 ### Added

--- a/src/telegram_sendmail/parser.py
+++ b/src/telegram_sendmail/parser.py
@@ -419,17 +419,12 @@ class EmailParser:
         body += _TRUNCATED_FOOTER if truncated else ""
         body += _ATTACHMENT_FOOTER if parsed.has_attachments else ""
 
-        sender = (
-            html.escape(parsed.sender) if parsed.sender else "<i>(unknown sender)</i>"
-        )
-        subject = (
-            html.escape(parsed.subject) if parsed.subject else "<i>(no subject)</i>"
-        )
+        sender = html.escape(parsed.sender) if parsed.sender else "(unknown sender)"
+        subject = html.escape(parsed.subject) if parsed.subject else "(no subject)"
         content = body if body else "<i>(no content)</i>"
 
         return (
-            f"<b>📬 New Notification</b>\n"
-            f"<b>From:</b> {sender}\n"
-            f"<b>Subject:</b> {subject}\n\n"
+            f"📬 <b>{sender}</b>\n"
+            f"<i>{subject}</i>\n\n"
             f"<blockquote expandable>{content}</blockquote>"
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -152,7 +152,7 @@ _FAKE_PARSED = ParsedEmail(
     has_attachments=False,
 )
 
-_FAKE_FORMATTED = "<b>📬 New Notification</b>\nFormatted body"
+_FAKE_FORMATTED = "📬 <b>root@localhost</b>\nFormatted body"
 
 
 class _SpoolerOk:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -509,9 +509,8 @@ class TestFormatForTelegram:
 
     def test_output_contains_telegram_envelope_header(self, app_config: AppConfig):
         result = EmailParser(app_config).format_for_telegram(_make_parsed())
-        assert "📬 New Notification" in result
-        assert "<b>From:</b>" in result
-        assert "<b>Subject:</b>" in result
+        assert "📬 <b>user@example.com</b>" in result
+        assert "<i>Test Subject</i>" in result
 
     def test_output_wraps_body_in_expandable_blockquote(self, app_config: AppConfig):
         result = EmailParser(app_config).format_for_telegram(_make_parsed())


### PR DESCRIPTION
## Description

Collapses the Telegram message envelope from a three-line labeled header into
two lines, removing the static label overhead ("New Notification", "From:",
"Subject:") that consumed ~30 characters.

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build
- [ ] Chore (dependency bumps, config changes)

## Pre-Submission Checklist

<!-- All items must be checked before requesting review. -->

- [x] `pre-commit run --all-files` passes
- [x] `pytest` passes with coverage at or above the global 80% threshold
- [x] `python scripts/module_coverage.py` passes (90% gate on critical modules)
- [x] Tests added or updated for all changed logic
- [x] `CHANGELOG.md` updated under `[Unreleased]` (skip for no operator-visible effect)
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
