### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-03-30
+
 ### Fixed
 
 - Cap the assembled Telegram message at 4096 characters so that
@@ -145,7 +147,8 @@ Production release.
 | `75` | Transient failure — retriable error; daemon should retry.     |
 | `78` | Configuration error (missing file or missing required key).   |
 
-[Unreleased]: https://github.com/theodiv/telegram-sendmail/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/theodiv/telegram-sendmail/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/theodiv/telegram-sendmail/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/theodiv/telegram-sendmail/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/theodiv/telegram-sendmail/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/theodiv/telegram-sendmail/compare/v1.0.0...v1.1.0

--- a/src/telegram_sendmail/__init__.py
+++ b/src/telegram_sendmail/__init__.py
@@ -8,6 +8,6 @@ Hatchling reads `__version__` from this file via the `[tool.hatch.version]`
 path defined in `pyproject.toml`.
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Theodosios Divolis"
 __license__ = "MIT"


### PR DESCRIPTION
## Description

Bump version to **1.2.2**

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build
- [x] Chore (dependency bumps, config changes)

## Pre-Submission Checklist

<!-- All items must be checked before requesting review. -->

- [ ] `pre-commit run --all-files` passes
- [ ] `pytest` passes with coverage at or above the global 80% threshold
- [ ] `python scripts/module_coverage.py` passes (90% gate on critical modules)
- [ ] Tests added or updated for all changed logic
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (skip for no operator-visible effect)
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
