### PR TITLE
chore: bump pre-commit hook revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
         args: ["--branch", "main"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: mypy
         args: ["--config-file=pyproject.toml"]


### PR DESCRIPTION
Automated `pre-commit autoupdate` run. The `rev` values in
`.pre-commit-config.yaml` have been bumped to the latest tags.

Review the diff carefully before merging:
- Confirm the new hook versions are stable releases, not pre-releases.
- Run `pre-commit run --all-files` locally against the updated config
  to verify no new violations are introduced.